### PR TITLE
Fix AnimCube size on smaller screen sizes

### DIFF
--- a/src/components/AnimCube/index.js
+++ b/src/components/AnimCube/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useId } from "react";
+import { useEffect, useId, useRef } from "react";
 import AnimCube3 from "./AnimCube3";
 
 /**
@@ -14,9 +14,14 @@ export default function AnimCube({
   height = "219px",
 }) {
   const id = "animcube_" + useId();
+  const divRef = useRef();
   useEffect(() => {
     AnimCube3(`id=${id}&${params}`);
+    const canvas = divRef.current?.childNodes[0];
+    if (canvas) {
+      canvas.style.maxWidth = "100%";
+    }
   }, [params]);
 
-  return <div style={{ width, height }} id={id} />;
+  return <div ref={divRef} style={{ width, height, maxWidth: "100%" }} id={id} />;
 }


### PR DESCRIPTION
Added a fix for AnimCube so it will shrink if the screen width is small.

Before:
![image](https://github.com/mjstraughan/CubingHistory/assets/50253028/f1be7f91-aa7e-47af-b681-a3d813e627ef)


After:
![image](https://github.com/mjstraughan/CubingHistory/assets/50253028/d4c4a704-0665-486a-a17d-723bcc5830b4)
