### PR TITLE
Add Exhibit, ReconViewer embeds

### DIFF
--- a/docs/3x3/Methods/2GR.md
+++ b/docs/3x3/Methods/2GR.md
@@ -1,8 +1,15 @@
-import AnimCube from "@site/src/components/AnimCube";
+import Exhibit from "@site/src/components/Exhibit";
 
 # 2GR
 
-<AnimCube params="config=../../ExhibitConfig.txt&facelets=dldlyldlddwwlwldlddlddbddlddlddgddlgddddoddooddddrdddd" width="400px" height="400px" />
+<Exhibit
+  stickering={{
+    solved: "U D F B L R DL DBL",
+    orientedWithoutPermutation: "UL UF UR UB FL FR BL BR DF DR DB"
+  }}
+  cameraLatitude={30}
+  cameraLongitude={-20}
+/>
 
 ## Description
 

--- a/docs/World Records/WorldRecordSingles2H.md
+++ b/docs/World Records/WorldRecordSingles2H.md
@@ -4,14 +4,28 @@ description: History of Rubik's Cube world records. The achievements of Feliks Z
 ---
 
 import AnimCube from "@site/src/components/AnimCube";
+import ReconViewer from "@site/src/components/ReconViewer";
 
 # World Record Singles (2H)
 
 ## 22.95 (Minh Thai) - Rubik's Cube World Championship (1982)
 
-<AnimCube params="config=../../ReconstructionConfig.txt&move={Scramble: U L2 D' B2 U' R2 B2 F2 D' F2 L2 R2 F R2 D L2 R2 B' L' D' R F'}{Inspection: x2 y}x2 y.{First layer corners and one edge: D' R u D R' y' D' R D R'}D' R u D R' y' D' R D R'.{First layer center and second edge: y D r' E' L}y D r' E' L.{CLL: z2 U y l D R' z' R' x z' r' R2 U2 z D R2 D2}z2 U y l D R' z' R' x z' r' R2 U2 z D R2 D2.{First layer third edge: R' l' z M D2 M'}R' l' z M D2 M'.{Last layer first edge: z2 y R z' M z R'}z2 y R z' M z R'.{Last layer second edge: z' r' L' z D R' E R}z' r' L' z D R' E R.{Last layer third edge: U' u' R E' R'}U' u' R E' R'.{Last six edges: u R' E' R E2 R E R'}u R' E' R E2 R E R'.{Last four centers: R2 E E' r2 E M2 E'}R2 E E' r2 E M2 E'&initmove=U L2 D' B2 U' R2 B2 F2 D' F2 L2 R2 F R2 D L2 R2 B' L' D' R F'" width="600px" height="400px" />
-
 **22.95 second solve by Minh Thai**
+
+<ReconViewer
+  scramble="U L2 D' B2 U' R2 B2 F2 D' F2 L2 R2 F R2 D L2 R2 B' L' D' R F'"
+  solution={`x2 y . // Inspection
+D' R u D R' y' D' R D R' . // First layer corners and one edge
+y D r' E' L . // First layer center and second edge
+z2 U y l D R' z' R' x z' r' R2 U2 z D R2 D2 . // CLL
+R' l' z M D2 M' . // First layer third edge
+z2 y R z' M z R' . // Last layer first edge
+z' r' L' z D R' E R . // Last layer second edge
+U' u' R E' R' . // Last layer third edge
+u R' E' R E2 R E R' . // Last six edges
+R2 E E' r2 E M2 E' . // Last four centers`}
+/>
+
 | **Method** | **Cube** | **Time** | **STM** | **STPS** | **ETM** | **ETPS** |
 |------|------|----|-----|------|-----|------|
 | Corners First | Provided by competition | 22.95 | 58 | 2.53 | 75 | 3.27 |
@@ -71,9 +85,20 @@ https://www.worldcubeassociation.org/competitions/CaltechWinter2004/results/all?
 
 ## 13.93 and 12.11 (Shotaro Makisumi)
 
-<AnimCube params="config=../../ReconstructionConfig.txt&move={Scramble: B R D2 F2 R F2 U D F2 R2 L2 D' U' R2 U2 F' L' B2 F R U2 R' B F U2}{Inspection: z2 y'}z2 y'.{Cross: R F R U' R}R F R U' R.{First Pair: R' U2 R2 U R'}R' U2 R2 U R'.{Second Pair: d R U' R' U2 F' U' F}d R U' R' U2 F' U' F.{Third Pair: L' U' L2 U L'}L' U' L2 U L'.{Fourth Pair: U L' U L}U L' U L.{OLL: y2 F R U R' U' F'}y2 F R U R' U' F'.{PLL: U y R B' R F2 R' B R F2 R2}U y R B' R F2 R' B R F2 R2&initmove=B R D2 F2 R F2 U D F2 R2 L2 D' U' R2 U2 F' L' B2 F R U2 R' B F U2" width="600px" height="400px" />
-
 **12.11 second solve by Shotaro Makisumi**
+
+<ReconViewer
+  scramble="B R D2 F2 R F2 U D F2 R2 L2 D' U' R2 U2 F' L' B2 F R U2 R' B F U2"
+  solution={`z2 y' . // Inspection
+R F R U' R . // Cross
+R' U2 R2 U R' . // First Pair
+d R U' R' U2 F' U' F . // Second Pair
+L' U' L2 U L' . // Third Pair
+U L' U L . // Fourth Pair
+y2 F R U R' U' F' . // OLL
+U y R B' R F2 R' B R F2 R2 . // PLL`}
+/>
+
 | **Method** | **Cube** | **Time** | **STM** | **STPS** | **ETM** | **ETPS** |
 |------|------|----|-----|------|-----|------|
 | CFOP | Unknown | 12.11 | 43 | 3.55 | 47 | 3.88 |
@@ -85,9 +110,20 @@ At Caltech Spring 2004, Makisumi set a record of 13.93 seconds during the first 
 
 ## 11.75 to 10.36
 
-<AnimCube params="config=../../ReconstructionConfig.txt&initmove=D2 L D2 U2 F' U R2 B L R' B2 L F' L R D' U2&move={Scramble: D2 L D2 U2 F' U R2 B L R' B2 L F' L R D' U2}{Inspection: y2}y2.{Cross: r U x' U R' U R' z2 y' D2'}r U x' U R' U R' z2 y' D2'.{1st pair: U R' U' R2 U R'}U R' U' R2 U R'.{2nd pair: U' y' U' R U' R' U2 R U' R'}U' y' U' R U' R' U2 R U' R'.{3rd pair: U y R' U2 R U R' U' R}U y R' U2 R U R' U' R.{4th pair: U' y U' R' U R U' R' U' R}U' y U' R' U R U' R' U' R.{OLL: U' R' U' R' F R F' U R}U' R' U' R' F R F' U R.{PLL: R U R' U' R' F R2 U' R' U' R U R' F'}R U R' U' R' F R2 U' R' U' R U R' F'" width="600px" height="400px" />
-
 **11.75 second solve by Jean Pons**
+
+<ReconViewer
+  scramble="D2 L D2 U2 F' U R2 B L R' B2 L F' L R D' U2"
+  solution={`y2 . // Inspection
+r U x' U R' U R' z2 y' D2' . // Cross
+U R' U' R2 U R' . // 1st pair
+U' y' U' R U' R' U2 R U' R' . // 2nd pair
+U y R' U2 R U R' U' R . // 3rd pair
+U' y U' R' U R U' R' U' R . // 4th pair
+U' R' U' R' F R F' U R . // OLL
+R U R' U' R' F R2 U' R' U' R U R' F' . // PLL`}
+/>
+
 | **Method** | **Cube** | **Time** | **STM** | **STPS** | **ETM** | **ETPS** |
 |------|------|----|-----|------|-----|------|
 | CFOP | Unknown | 11.75 | 62 | 5.28 | 69 | 5.87 |

--- a/scripts/animcube-recon-to-reconviewer.js
+++ b/scripts/animcube-recon-to-reconviewer.js
@@ -1,0 +1,45 @@
+/*
+This script helps migrate the site from Animcube to cubing.js for reconstructions specifically
+It allows batch converting an Animcube applet with ReconstructionConfig to our new `<ReconViewer>` component powered by cubing.js
+How to use:
+1. Copy the contents of each applet's `config="..."` to `paramsList`, each on separate lines
+2. Run this script with `node scripts/animcube-recon-to-reconviewer.js`
+3. Script generates the React code for `<ReconViewer>`, copy paste back into the Markdown files
+*/
+
+// ADD MORE LINES HERE
+const paramsList = `
+config=../../ReconstructionConfig.txt&move={Scramble: U L2 D' B2 U' R2 B2 F2 D' F2 L2 R2 F R2 D L2 R2 B' L' D' R F'}{Inspection: x2 y}x2 y.{First layer corners and one edge: D' R u D R' y' D' R D R'}D' R u D R' y' D' R D R'.{First layer center and second edge: y D r' E' L}y D r' E' L.{CLL: z2 U y l D R' z' R' x z' r' R2 U2 z D R2 D2}z2 U y l D R' z' R' x z' r' R2 U2 z D R2 D2.{First layer third edge: R' l' z M D2 M'}R' l' z M D2 M'.{Last layer first edge: z2 y R z' M z R'}z2 y R z' M z R'.{Last layer second edge: z' r' L' z D R' E R}z' r' L' z D R' E R.{Last layer third edge: U' u' R E' R'}U' u' R E' R'.{Last six edges: u R' E' R E2 R E R'}u R' E' R E2 R E R'.{Last four centers: R2 E E' r2 E M2 E'}R2 E E' r2 E M2 E'&initmove=U L2 D' B2 U' R2 B2 F2 D' F2 L2 R2 F R2 D L2 R2 B' L' D' R F'
+config=../../ReconstructionConfig.txt&move={Scramble: B R D2 F2 R F2 U D F2 R2 L2 D' U' R2 U2 F' L' B2 F R U2 R' B F U2}{Inspection: z2 y'}z2 y'.{Cross: R F R U' R}R F R U' R.{First Pair: R' U2 R2 U R'}R' U2 R2 U R'.{Second Pair: d R U' R' U2 F' U' F}d R U' R' U2 F' U' F.{Third Pair: L' U' L2 U L'}L' U' L2 U L'.{Fourth Pair: U L' U L}U L' U L.{OLL: y2 F R U R' U' F'}y2 F R U R' U' F'.{PLL: U y R B' R F2 R' B R F2 R2}U y R B' R F2 R' B R F2 R2&initmove=B R D2 F2 R F2 U D F2 R2 L2 D' U' R2 U2 F' L' B2 F R U2 R' B F U2
+`;
+
+function animcubeParamsToReconViewer(params) {
+  const regexp = /{.*?}/g;
+  // get only the stuff within the curly braces
+  const lines = [...params.matchAll(regexp)].map(line => line[0]);
+  const formatted = lines.map(line => {
+    // take out the curly braces
+    const withoutBraces = line.substring(1, line.length - 1);
+    // get the comment and moves
+    const [comment, moves] = withoutBraces.split(": ");
+    return { comment, moves };
+  })
+
+  const scramble = formatted[0].moves;
+  const solution = formatted.slice(1).map(({ comment, moves }) => {
+    return `${moves} . // ${comment}`;
+  }).join("\n");
+
+  return `<ReconViewer
+  scramble="${scramble}"
+  solution={\`${solution}\`}
+/>`;
+}
+
+paramsList
+  .split("\n")
+  .filter(l => l)
+  .forEach((params, index) => {
+    console.log(`Reconstruction #${index + 1}:\n`);
+    console.log(animcubeParamsToReconViewer(params) + "\n\n");
+  });

--- a/src/components/Exhibit/index.js
+++ b/src/components/Exhibit/index.js
@@ -1,0 +1,83 @@
+import TwistyPlayer from "../TwistyPlayer";
+
+/**
+ * Method exhibit component
+ * Uses special syntax to make it easier to define custom stickering
+ * Stickering options are solved, dim, ignored, permuted, oriented, orientedWithoutPermutation, invisible
+ * For each option, pass in a string with piece names separated by spaces.
+ * THe camera latitude and longitude can be set as well (both default to 45 degrees)
+ * Below is 2GR example:
+ * @example
+ * <Exhibit
+  stickering={{
+    solved: "U D F B L R DL DBL",
+    orientedWithoutPermutation: "UL UF UR UB FL FR BL BR DF DR DB"
+  }}
+  defaultOption="ignored"
+  cameraLatitude={30}
+  cameraLongitude={-20}
+/>
+ */
+export default function Exhibit({
+  stickering,
+  defaultOption = "ignored",
+  cameraLatitude = 45,
+  cameraLongitude = 45,
+}) {
+  const defaultStickeringChar = STICKERING_CHARS_MAP[defaultOption];
+  const edges = Array(12).fill(defaultStickeringChar);
+  const corners = Array(8).fill(defaultStickeringChar);
+  const centers = Array(6).fill(defaultStickeringChar);
+
+  for (const [option, pieces] of Object.entries(stickering)) {
+    for (const piece of pieces.toUpperCase().split(" ")) {
+      const stickeringChar = STICKERING_CHARS_MAP[option];
+      if (piece.length === 1) {
+        centers[centerIndices[piece]] = stickeringChar;
+      } else if (piece.length === 2) {
+        edges[edgeIndices[piece]] = stickeringChar;
+      } else {
+        corners[cornerIndices[piece]] = stickeringChar;
+      }
+    }
+  }
+
+  const maskOrbits = `EDGES:${edges.join("")},CORNERS:${corners.join("")},CENTERS:${centers.join("")}`;
+  return <TwistyPlayer
+    controlPanel="none"
+    cameraLatitude={cameraLatitude}
+    cameraLongitude={cameraLongitude}
+    rotateStickering="x2"
+    experimentalStickeringMaskOrbits={maskOrbits}
+  />
+}
+
+const STICKERING_CHARS_MAP = {
+  solved: "-",
+  dim: "D",
+  ignored: "I",
+  permuted: "P",
+  oriented: "O",
+  orientedWithoutPermutation: "?",
+  invisible: "X",
+};
+
+const centerIndices = {
+  U: 0,
+  L: 1,
+  F: 2,
+  R: 3,
+  B: 4,
+  D: 5,
+};
+
+const edgeIndices = {
+  UF: 0, UR: 1, UB: 2, UL: 3,
+  DF: 4, DR: 5, DB: 6, DL: 7,
+  FR: 8, FL: 9, BR: 10, BL: 11,
+};
+
+const cornerIndices = {
+  UFR: 0, UBR: 1, UBL: 2, UFL: 3,
+  DFR: 4, DFL: 5, DBL: 6, DBR: 7,
+};

--- a/src/components/ReconViewer/ReconViewer.module.css
+++ b/src/components/ReconViewer/ReconViewer.module.css
@@ -1,0 +1,27 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.twistyPlayer {
+  width: 100%;
+}
+
+@media screen and (min-width: 1600px) {
+  .container {
+    flex-direction: row;
+  }
+
+  .twistyPlayer {
+    width: 500px;
+  }
+}
+
+.recon {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 1.1rem;
+}

--- a/src/components/ReconViewer/index.js
+++ b/src/components/ReconViewer/index.js
@@ -1,0 +1,73 @@
+import { TwistyAlgViewer, TwistyPlayer } from "cubing/twisty";
+import { useEffect, useRef } from "react";
+import styles from "./ReconViewer.module.css";
+
+/**
+ * Displays a reconstruction of a solve.
+ * @example
+ * <ReconViewer
+    scramble="B R D2 F2 R F2 U D F2 R2 L2 D' U' R2 U2 F' L' B2 F R U2 R' B F U2"
+    solution={`z2 y' . // Inspection
+  R F R U' R . // Cross
+  R' U2 R2 U R' . // First Pair
+  d R U' R' U2 F' U' F . // Second Pair
+  L' U' L2 U L' . // Third Pair
+  U L' U L . // Fourth Pair
+  y2 F R U R' U' F' . // OLL
+  U y R B' R F2 R' B R F2 R2 . // PLL`}
+  />
+ */
+export default function ReconViewer({ scramble, solution }) {
+  const player = useRef(null);
+  const playerContainer = useRef(null);
+  const algViewer = useRef(null);
+  const algViewerContainer = useRef(null);
+
+  // Initial setup for the twisty player and alg viewer
+  useEffect(() => {
+    if (!playerContainer.current || !algViewerContainer.current) {
+      return;
+    }
+
+    // Create the Twisty Player
+    player.current = new TwistyPlayer({
+      // Twisty Player settings
+      background: "none",
+      tempoScale: 1.5,
+    });
+    player.current.className = styles.twistyPlayer;
+
+    // Create the Twisty Alg Viewer
+    algViewer.current = new TwistyAlgViewer({ twistyPlayer: player.current });
+
+    // Add the player and alg viewer to their containers
+    playerContainer.current.appendChild(player.current);
+    algViewerContainer.current.appendChild(algViewer.current);
+
+    // Cleanup: when component unmounts, delete the player and alg viewer
+    return () => {
+      playerContainer.current?.replaceChildren();
+      algViewerContainer.current?.replaceChildren();
+    }
+  }, []);
+
+  // Update the player if scramble or solution changes
+  useEffect(() => {
+    if (!player.current) return;
+    player.current.experimentalSetupAlg = scramble;
+    player.current.alg = solution;
+    player.current.jumpToStart();
+  }, [scramble, solution]);
+
+  return (
+    <div className={styles.container}>
+      <div ref={playerContainer} />
+      <div className={styles.recon}>
+        <strong>Scramble:</strong>
+        <span>{scramble}</span>
+        <strong>Solution:</strong>
+        <div ref={algViewerContainer} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces 3 new components, 2 of which facilitate migration from AnimCube to cubing.js on the site.

## 1. Exhibit
`<Exhibit>` is a replacement for AnimCube with ExhibitConfig.txt. Shows a cube with piece-based custom stickering and no playback controls. I created a syntax that makes it easier to define custom stickerings.

Before: (example: 2GR)
<img width="457" height="431" alt="Screenshot 2025-08-15 at 7 12 59 PM" src="https://github.com/user-attachments/assets/e860de92-aa9e-431a-8076-20f3c0b37ac5" />

After:
<img width="418" height="412" alt="Screenshot 2025-08-15 at 7 12 34 PM" src="https://github.com/user-attachments/assets/1ee16b0d-8b89-45f4-ab9a-499ae9edae2c" />

Distance of hint facelets is still fixed. If adjustability is a requirement then feel free to delay merging this PR until cubing.js supports it.

## 2. ReconViewer
`<ReconViewer>` is a replacement for AnimCube with ReconstructionConfig.txt. Shows a cube side-by-side with reconstruction, which can be played back. On smaller screens, layout adapts so the reconstruction is shown underneath the cube.

Before:
<img width="950" height="508" alt="Screenshot 2025-08-15 at 7 18 10 PM" src="https://github.com/user-attachments/assets/47884d0c-82b3-44ae-b6e5-ed87f26a4783" />

After:
<img width="992" height="604" alt="Screenshot 2025-08-15 at 7 17 54 PM" src="https://github.com/user-attachments/assets/c3b2b049-10f6-4bbc-9fbd-8dc22b441058" />

It would be very tedious to migrate these AnimCube widgets because the syntax of the reconstructions needs to be changed. To make it easier, I created a script in a new folder `scripts/animcube-recon-to-reconviewer` that automatically translates AnimCube reconstructions to cubing.js format.
- Note: the script only considers the contents of the AnimCube visual comments (inside the curly braces). Visual comments are assumed to follow this format: a comment about the step, followed by ": " and then the moves. If the visual comments don't follow this format then the script won't work.

## Migration
I've migrated the 2GR page to use `<Exhibit>`, and the first few embeds of the WR singles page with `<ReconViewer>`.
Please let me know what you think, I'm happy to make changes. After that, you'll need to continue the migration with these three components.