### PR TITLE
Migrate to <YouTube> component

### DIFF
--- a/docs/2x2/Methods/CCLL.md
+++ b/docs/2x2/Methods/CCLL.md
@@ -1,4 +1,5 @@
 import AnimCube2x2 from "@site/src/components/AnimCube2";
+import YouTube from "@site/src/components/YouTube";
 
 # CCLL
 
@@ -27,13 +28,7 @@ This concept was first developed by Michael James Straughan in 2012 [1].
 
 In 2018, Joseph Briggs independently proposed the same concept as an application of the 42 method to the 2x2x2.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/AJjT5bYknls"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="AJjT5bYknls" />
 
 ## References
 

--- a/docs/2x2/Methods/RoFL.md
+++ b/docs/2x2/Methods/RoFL.md
@@ -1,4 +1,5 @@
 import AnimCube2x2 from "@site/src/components/AnimCube2";
+import YouTube from "@site/src/components/YouTube";
 
 # RoFL
 
@@ -40,13 +41,7 @@ In November, 2023, Hitchcock started development on the entire method, eventuall
 
 ![](img/RoFL/CBLAlgSheet.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/3fnvk7kclDw"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="3fnvk7kclDw" />
 
 ## TCLL
 

--- a/docs/3x3/3x3Notation.md
+++ b/docs/3x3/3x3Notation.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 description: History of Rubik's Cube Notation
 ---
 
+import YouTube from "@site/src/components/YouTube";
+
 # Notation
 
 ## Outer Turns
@@ -36,13 +38,7 @@ Throughout the years, many have questioned the direction that the M, E, and S no
 ![](img/Notation/Williams1.png)
 ![](img/Notation/Williams2.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/24eHm4ri8WM?start=51"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="24eHm4ri8WM?start=51" />
 
 > Thanks to xyzzy for pointing out the alphabetical order mention in this video.
 

--- a/docs/3x3/HardwareEvolution.md
+++ b/docs/3x3/HardwareEvolution.md
@@ -6,6 +6,7 @@ description: The history of Rubik's Cube hardware innovations, such as magnets, 
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # Hardware Evolution
 
@@ -336,13 +337,7 @@ In February 2016, Julien Adam posted the idea of a repel only 3x3x3 on SpeedSolv
 
 On August 19 2016, Chris Tran posted a video to YouTube showing that he had modified a ShengShou FangYuan 3x3x3 to add internal magnets [44]. The arrangement was the same as Wilson’s Zhanchi modification, with four magnets inside of each center cap and two magnets inside of each edge.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/bBEkEapVLIU"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="bBEkEapVLIU" />
 <br />
 ![](img/HardwareEvolution/Tran1.webp)
 
@@ -389,13 +384,7 @@ On September 22 2016, Tran posted a video to YouTube demonstrating magnets appli
 
 ![](img/HardwareEvolution/Tran2.webp)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/o7aTjVGa1d0"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="o7aTjVGa1d0" />
 <br />
 Making it clear that they weren't done with applying magnets to puzzles, on October 29 2016, MoYu announced the MoYu Magnetic Skewb [53].
 
@@ -432,13 +421,7 @@ Some even produced tutorials for modifying puzzles to include magnets. The first
 
 ![](img/HardwareEvolution/Zhao.webp)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/mouftEig8Gk"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="mouftEig8Gk" />
 <br />
 ![](img/HardwareEvolution/Miller.webp)
 
@@ -461,13 +444,7 @@ images={[
 
 In September 2018, GAN released a teaser video for the first production 3x3x3 with an adjustable magnet strength [59]. The magnets within each edge are directly across from each other on opposite sides and connected through a rod. The packaging comes with sets of additional magnet rods of varying strength that the user can push through and replace the currently inserted rods. The cube was released under the name “356X” in October 2018 [60].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/9QomqgRQR9o"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="9QomqgRQR9o" />
 
 ![](img/HardwareEvolution/GAN.webp)
 

--- a/docs/3x3/Methods/3Color.md
+++ b/docs/3x3/Methods/3Color.md
@@ -6,6 +6,7 @@ id: 3Color
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # 3-Color
 
@@ -72,31 +73,13 @@ In February 2009, Christos published his 3-Color solution, making it available f
 ![](img/3-Color/Christos2.png)
 <br/>
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/upub1rOvfqI"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="upub1rOvfqI" />
 <br/>
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/18_WoFQp8WQ"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="18_WoFQp8WQ" />
 <br/>
 In July 2016, Christos made the booklet available for free through a YouTube video that displays each page of the booklet [12]. On January 18 2025, Christos posted a comment on the video with a link to the .pdf version of the booklet [13]. A backup link to the booklet is <a href="/archive/MethodFiles/g_christos_soln_rubics_cube_3x3.pdf ">here</a>. On the same day, Christos posted a short video to his Facebook page with an example solve of his method [14, 15].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/2t_EIyowSIY"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="2t_EIyowSIY" />
 <br/>
 <ImageCollage
 images={[

--- a/docs/3x3/Methods/CornersFirst.md
+++ b/docs/3x3/Methods/CornersFirst.md
@@ -5,6 +5,7 @@ description: History of the Corners First method for the Rubik's Cube.
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # Corners First
 
@@ -75,13 +76,7 @@ The steps of Minh Thai’s method, as described in _The Winning Solution_, are a
 3. Solve three edges of one side, three edges of the opposite side, then simultaneously solve the final two opposite side edges.
 4. Orient the final middle layer edges then permute the edges.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/zVkZEQeUk-g"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="zVkZEQeUk-g" />
 
 ### Others
 

--- a/docs/3x3/Methods/Roux.md
+++ b/docs/3x3/Methods/Roux.md
@@ -5,6 +5,7 @@ description: History of the Roux method for the Rubik's Cube.
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # Roux
 
@@ -158,25 +159,13 @@ In 2012, Straughan proposed a new 4c recognition method with a focus on providin
 
 ![](img/Roux/DFDB.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/LKXdVfNaLao"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="LKXdVfNaLao" />
 
 After the proposal and development, the community named the system "DFDB" and added on a way to improve recognition for 4c 3-cycle cases that start with an M2 move. The first known to have improved the M2 start cases is Yuta Sasaki (佐々木雄太). In February 2013 Sasaki wrote a blog post detailing the original DFDB proposal by Straughan, while also describing a way to determine if a 3-cycle permutation will start with an M2 move [29].
 
 ![](img/Roux/Sasaki.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/vW0bBDdoPlk"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="vW0bBDdoPlk" />
 
 ### CMLLEO
 

--- a/docs/3x3/Methods/Squall.md
+++ b/docs/3x3/Methods/Squall.md
@@ -1,4 +1,5 @@
 import AnimCube from "@site/src/components/AnimCube";
+import YouTube from "@site/src/components/YouTube";
 
 # Squall
 
@@ -37,13 +38,7 @@ In 2022, Trang was interviewed as part of the Methodical Cubing Podcast. Trang d
 
 Squall was developed backwards, with a focus on ending with a quality 2-gen step. Eventually, Trang settled on L5EP as the final step because it has few cases and a good move count. The natural idea for the two steps to come before L5EP was to solve two pairs then the upper layer corners. This left a 2x2x3 block with all edges oriented. To achieve this state, Trang decided to solve the DF and DB edges while preserving an edge orientation step that would come earlier in the solve. This leaves a first step that is commonly called EOFB, or edge orientation and a 1x2x3 block. Trang felt that this is too much to plan in inspection, so it was decided to split the step into two. The first part being to orient all edges while building a 1x2x2 block, called EOSquare, then add a corner and edge pair to the 1x2x2 block to complete the 1x2x3 block.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/IGOAQc3l_jg?start=262"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="IGOAQc3l_jg?start=262" />
 
 ## References
 

--- a/docs/3x3/Steps/ZBLL.md
+++ b/docs/3x3/Steps/ZBLL.md
@@ -1,4 +1,5 @@
 import AnimCube from "@site/src/components/AnimCube";
+import YouTube from "@site/src/components/YouTube";
 
 # ZBLL
 
@@ -89,13 +90,12 @@ BH was proposed in 2004-2005 by Dan Harris and Jason Baum [10, 11].
 
 Tran Style recognition was first mentioned in 2015 in a seminar by Chris Tran then detailed in February 2016.
 
-<iframe width="640" height="360" src="https://www.youtube.com/embed/JyW1dm6mG-s" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
+<YouTube embedId="JyW1dm6mG-s" />
 ### No Corner Permutation (NCP)
 
 No Corner Permutation (NCP) was developed in November 2021 by Ryan Hudgens [12].
 
-<iframe width="640" height="360" src="https://www.youtube.com/embed/6fMDp5o2Ca8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<YouTube embedId="6fMDp5o2Ca8" />
 
 ![](img/ZBLL/NCP.png)
 

--- a/docs/BlindfoldSolving/BlindfoldSolvingOrigins.md
+++ b/docs/BlindfoldSolving/BlindfoldSolvingOrigins.md
@@ -6,6 +6,7 @@ description: History of blindfold solving the Rubik's Cube.
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # Blindfold Solving Origins
 
@@ -69,13 +70,7 @@ images={[
 ]}
 />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/VZuC1lXnUcc"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="VZuC1lXnUcc" />
 
 ## First Multi-Blind Solvers
 

--- a/docs/BlindfoldSolving/Methods/Orozco.md
+++ b/docs/BlindfoldSolving/Methods/Orozco.md
@@ -5,6 +5,7 @@ description: History of the Orozco blindfold solving method for the Rubik's Cube
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # Orozco
 
@@ -46,13 +47,7 @@ images={[
 
 On November 9, 2013, Gabriel Alejandro Orozco Casillas posted a video of a new blindfold solving method, which eventually became known as Orozco [3]. Elements of his previously proposed U2 method can be seen within Orozco, so it is possible that the idea of Orozco arose from the thought process behind the U2 method. It took some time before the Orozco method reached the non-Spanish speaking community. It is likely that the rest of the community first learned of the method through a thread by Jayden McNeill on SpeedSolving.com. In the thread, McNeill described the method, compared and contrasted it with the M2 method, and included an example solve [4].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/qutNt4f5z8g"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="qutNt4f5z8g" />
 
 <ImageCollage
 images={[

--- a/docs/BlindfoldSolving/Methods/UF5.md
+++ b/docs/BlindfoldSolving/Methods/UF5.md
@@ -5,6 +5,7 @@ description: History of the UF5 blindfold solving method for the Rubik's Cube.
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # UF5
 
@@ -49,13 +50,7 @@ Although the idea had been suggested numerous times in the past, it hadn’t bee
 
 In June 2018, Ghodgaonkar posted a video to YouTube detailing a new way to memorize blindfold solving algorithms [12]. Then, in January 2019, he announced that he was developing it into a mnemonic system called “Yo Notation” that is intended to make algorithm memorization easier [13]. The notation document was developed and published in February 2019 [14, 15, 16].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/y56Ljj4TeEg"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="y56Ljj4TeEg" />
 
 <ImageCollage
 images={[
@@ -101,34 +96,16 @@ images={[
 ]}
 />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/-SantOHuPcs"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="-SantOHuPcs" />
 <br />
 
 Ghodgaonkar even went as far as compiling a survey to ask the community how they felt about UF5 [27, 28]. Many responses reflected the negative opinions expressed in the message board posts and Facebook groups. Some respondents, both to the surveys and online message boards and groups, were more optimistic, comparing it to the ZBLL and ZBLS algorithm sets [29, 27, 28]. It was noted that for several years after the proposals of ZBLL and ZBLS many doubted the viability of learning and recalling the large number of algorithms, yet the two algorithm sets are now being learned and implemented into competition solves. After putting effort into development, practice, and considering the feedback from the community, Ghodgaonkar settled on a mixed opinion [30]:
 
 > I was in two minds always, one mind thinking that method will not give any returns, and the other was that this method will just restructure the human brain, as to how we consume information and the thin line between memorisation and understanding a thing fully that we are able to reconstruct it.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/Le8dVjF5Jog"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="Le8dVjF5Jog" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/F8VSVnCXx5k"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="F8VSVnCXx5k" />
 <br />
 
 <ImageCollage

--- a/docs/BlindfoldSolving/Techniques.md
+++ b/docs/BlindfoldSolving/Techniques.md
@@ -5,6 +5,7 @@ description: History of techniques for blindfold solving the Rubik's Cube.
 import AnimCube from "@site/src/components/AnimCube";
 import ReactPlayer from 'react-player'
 import ImageCollage from '@site/src/components/ImageCollage';
+import YouTube from "@site/src/components/YouTube";
 
 # Techniques
 
@@ -40,25 +41,13 @@ images={[
 ]}
 />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/hpxOIQ6j0rk"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="hpxOIQ6j0rk" />
 
 ### Popularization
 
 Many blindfold solvers implemented floating buffers into their solves starting in the late 2010s. However, widespread use of the technique can be traced to at least one point in time. In January 2016, Gianfranco Huanqui achieved a 3x3 blindfold solving continental record time of 21.51 seconds [11]. In the solve, Huanqui made use of the technique, catching the attention of several people in the community. One of those people who took notice of the solve was Jayden McNeill. Impressed by the use of floating buffers within such a high level solve in competition, McNeill posted a thread to SpeedSolving.com attempting to standardize the process in a way that could be consistently implemented [12].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/Og-E8v1rihc"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="Og-E8v1rihc" />
 
 ![](img/Techniques/McNeill.png)
 
@@ -124,13 +113,7 @@ In June of 2022, Wong and Kobelansky started development on T2C, together devisi
 ![](img/Techniques/Wong.png)
 ![](img/Techniques/T2C.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/NKNAE-0FTBA?start=1109s"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="NKNAE-0FTBA?start=1109s" />
 
 ### Credit
 
@@ -144,13 +127,7 @@ In the earlier years of blindfold solving, the typical strategy used to solve pa
 
 The most common way of solving parity is to use a technique called “memo swap” or “pseudo swap”. Using this technique, instead of separately solving the final target and solving parity, the parity solving is built into the final piece target. The final target is solved while positioning the piece currently in the target position to the UR position. For edges this creates a cycle of UF > Target > UR if using UF as the buffer position. Solvers typically memorize the corners first then, if parity exists, the edges are memorized and solved to have the UF and UR edges swapped. It is unknown from where the technique originated, but it has been used at least as far back as 2012, as shown by its use by Noa Arthurs in a tutorial video [24].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/1xGbJ4ic6oE?start=134s"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="1xGbJ4ic6oE?start=134s" />
 
 ### Full Parity
 
@@ -174,13 +151,7 @@ images={[
 
 Aside from the M slice, slice turns weren’t always in heavy use during blindfold solving. This is likely because the ergonomics for E and S slice turns hadn’t yet been strenuously tested within blindfold solves. In addition, outer turns were likely considered safer, with less risk of improperly executing the turns. Eventually E and S moves started making their appearance in top level solves, and it is thought that Gianfranco Huanqui popularized the use of E and S turns in blindfold solving [8]. A notable example of slice turn use is the 23.68 world record solve by Marcin Zalewski, which included the use of E slice turns in two of the edge solving targets [29]. Huanqui stated that he saw the use of E slice commutators in Zalewski’s world record solve and was inspired to use it in any situation possible [9]. In addition to implementing E slice moves, Huanqui also started using S slice moves. Huanqui believes that this came about either naturally after having experimented with E slice moves or from discussions with Ishaan Agrawal, who had been using S slice moves at the time [9].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/-QHaiTRec_8"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="-QHaiTRec_8" />
 
 ## References
 

--- a/docs/FTO/FTOHistory.md
+++ b/docs/FTO/FTOHistory.md
@@ -3,6 +3,8 @@ sidebar_position: 1
 description: History of the Face Turning Octahedron (FTO)
 ---
 
+import YouTube from "@site/src/components/YouTube";
+
 # FTO History
 
 ## Early Patents
@@ -44,13 +46,7 @@ According to a post on ptt.cc, 1000 units of the puzzle were produced in Taiwan 
 ![](img/Hardware/Xie4.png)
 ![](img/Hardware/Xie5.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/BFSorFjezO8"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="BFSorFjezO8" />
 
 ### David Pitcher
 

--- a/docs/FTO/Methods/Bencisco.md
+++ b/docs/FTO/Methods/Bencisco.md
@@ -3,6 +3,7 @@ description: History of the Bencisco method for the FTO
 ---
 
 import TwistyPlayer from "@site/src/components/TwistyPlayer";
+import YouTube from "@site/src/components/YouTube";
 
 # Bencisco
 
@@ -29,43 +30,19 @@ import TwistyPlayer from "@site/src/components/TwistyPlayer";
 
 Development on the Bencisco method started on April 1, 2018 [1] and the method was first shown in video form on YouTube on April 23, 2018 [2]. This video demonstrated the potential of the method with a solve time under one minute.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/HKKhHqHw8ps"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="HKKhHqHw8ps" />
 
 ## Release
 
 In September of 2019, Streeter officially revealed the steps of the method to the puzzle community. Initially the steps were presented through an example solve video [3] and, later on the same day, a video announcing the release of a document detailing the steps of the method [4]. A couple of days after the YouTube reveal, Streeter presented the complete method to the rest of the community through a post to TwistyPuzzles.com [5]. A few months later, Streeter released an in-depth tutorial for the method [6].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/XdgZcz5Pt9g"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="XdgZcz5Pt9g" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/dOx2mqe6cTw"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="dOx2mqe6cTw" />
 
 ![](img/Bencisco/Streeter1.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/tYeV8LvqVDY"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="tYeV8LvqVDY" />
 
 ## Name Origin
 

--- a/docs/Techniques/Pseudo.md
+++ b/docs/Techniques/Pseudo.md
@@ -1,4 +1,5 @@
 import AnimCube from "@site/src/components/AnimCube";
+import YouTube from "@site/src/components/YouTube";
 
 # Pseudo
 
@@ -96,13 +97,7 @@ In 2017, Joseph Briggs independently discovered the technique and incorporated i
 
 Upon proposal of the 42 method, Briggs provided a recognition method and algorithm document [15, 16]. The recognition method involves first checking the orientation of the U/D corner stickers. Then a pattern of additional stickers is compared with the right side sticker of the unsolved corner that is currently on the bottom layer.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/DZZZ2WvFiZs"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="DZZZ2WvFiZs" />
 
 ![](img/Pseudo/BriggsCCMLL.png)
 ![](img/Pseudo/BriggsCCMLL2.png)

--- a/docs/World Records/WorldRecordAverages2H.md
+++ b/docs/World Records/WorldRecordAverages2H.md
@@ -4,6 +4,7 @@ description: History of Rubik's Cube world record averages. The achievements of 
 ---
 
 import AnimCube from "@site/src/components/AnimCube";
+import YouTube from "@site/src/components/YouTube";
 
 # World Record Averages (2H)
 
@@ -25,13 +26,7 @@ Throughout 2004, Shotaro Makisumi reduced the world record average to 14.52. Sta
 | 15.38   | 15.29 16.64 17.65 (18.05) (14.76) | April 3, 2004    |
 | 14.52   | (13.16) 13.77 15.49 14.29 (15.60) | October 16, 2004 |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/aOmgT6GjZIg"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="aOmgT6GjZIg" />
 
 ## 14.40 and 13.22 (Anssi Vanhala)
 
@@ -42,13 +37,7 @@ On March 18, 2006, a year and a half after the 14.52 second average was set, the
 | 14.40   | (16.59) 14.18 15.29 (13.08) 13.74 | March 18, 2006 |
 | 13.22   | 14.08 12.81 12.77 (12.47) (14.09) | March 18, 2006 |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/eX-LRl6JA1Y"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="eX-LRl6JA1Y" />
 
 ## 11.76 to 10.07
 
@@ -67,53 +56,17 @@ From January 2007 to September 2009, the record was reduced to 10.07 seconds. Th
 | Tomasz Żołnowski | 10.63   | 10.88 10.19 10.81 (9.43) (DNF)    | April 4, 2009      |
 | Tomasz Żołnowski | 10.07   | 10.80 (12.08) 9.77 (8.68) 9.65    | September 26, 2009 |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/bZv_YtXwKzo"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="bZv_YtXwKzo" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/MUP0T_bH7Vc"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="MUP0T_bH7Vc" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/id2xtbfVbn8"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="id2xtbfVbn8" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/WYL2Gmpn0sA"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="WYL2Gmpn0sA" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/YJdGN0Opuvc"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="YJdGN0Opuvc" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/Kfvz0EU7_-Y"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="Kfvz0EU7_-Y" />
 
 ## 9.21 to 6.45 (Feliks Zemdegs)
 
@@ -142,21 +95,9 @@ In 2010, the sub-10 second barrier for the world record average was broken for t
 | 6.54    | 6.91 6.41 (6.25) (7.30) 6.31  | November 16, 2013 |
 | 6.45    | (7.16) 6.58 6.79 (5.88) 5.99  | July 9, 2016      |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/Lv54OeFQZOk"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="Lv54OeFQZOk" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/93KEXSfKp4c"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="93KEXSfKp4c" />
 
 ## 6.39 (Max Park)
 
@@ -173,13 +114,7 @@ In 2010, the sub-10 second barrier for the world record average was broken for t
 
 In 2017, for the first time in over seven years, Zemdegs’ streak was broken. On April 23, 2017, broke the world record with an average of 6.39 seconds. What people began to notice about Max Park’s solving style was his turns per second. This contrasted with Zemdegs’ solves which had lower turns per second, but were more move efficient.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/7hEVhvpcFZI"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="7hEVhvpcFZI" />
 
 ## 5.97 to 5.53 (Feliks Zemdegs)
 
@@ -203,21 +138,9 @@ In 2017, for the first time in over seven years, Zemdegs’ streak was broken. O
 | 5.69    | (6.90) 5.64 (5.57) 5.79 5.63 | April 6, 2019     |
 | 5.53    | (7.16) 5.04 (4.67) 6.55 4.99 | November 10, 2019 |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/kWUQbhbqvqo"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="kWUQbhbqvqo" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/Pj796Dd95-w"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="Pj796Dd95-w" />
 
 ## 5.48 to 5.08
 
@@ -241,37 +164,13 @@ From June 2021 to April 2022, the world record average was brought down to 5.08 
 | Tymon Kolasiński | 5.09    | (4.73) 4.83 5.24 (6.57) 5.20 | December 18, 2021 |
 | Max Park         | 5.08    | 4.88 (5.70) 5.56 (4.53) 4.80 | April 3, 2022     |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/UDbTMnGBuEQ"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="UDbTMnGBuEQ" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/QMRDcx0iTBc"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="QMRDcx0iTBc" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/BxWbYB4kI8M"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="BxWbYB4kI8M" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/X3UFiUnWIqc"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="X3UFiUnWIqc" />
 
 ## 4.86 (Tymon Kolasiński and Max Park)
 
@@ -305,21 +204,9 @@ On July 30, 2022, Kolasiński broke the sub-5 barrier with a 4.86 second average
 
 ![](img/WRAverages2H/MaxTymonComparison.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/yZywq-ROTbg"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="yZywq-ROTbg" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/s3ypNkatnwg"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="s3ypNkatnwg" />
 
 ## 4.69 to 4.09 (Yiheng Wang)
 
@@ -346,13 +233,7 @@ The 4.69 second average was the first of several world records. From June 2023 t
 | 4.25    | 4.76 3.98 (4.81) 4.00 (3.96) | August 25, 2024    |
 | 4.09    | 3.83 (5.16) 4.55 (3.71) 3.88 | September 21, 2024 |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/RcIFY4_PO3E"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="RcIFY4_PO3E" />
 
 ## Sources
 

--- a/docs/World Records/WorldRecordSingles2H.md
+++ b/docs/World Records/WorldRecordSingles2H.md
@@ -3,6 +3,7 @@ sidebar_position: 2
 description: History of Rubik's Cube world records. The achievements of Feliks Zemdegs, Max Park, Yiheng Wang, and more.
 ---
 
+import YouTube from "@site/src/components/YouTube";
 import AnimCube from "@site/src/components/AnimCube";
 
 # World Record Singles (2H)
@@ -28,13 +29,7 @@ The competition featured three rounds with each competitor solving the cube once
 
 Today, Minh Thai’s 22.95 solve time is considered the first ever official world record because it was performed in the first competition to be officially recognized by the WCA. Lower record solve times were achieved in the early 1980s, such as a 17.04 second solve by Robert Pergl in the 1983 Czechoslovakian Championship [3]. However, these other solves aren’t considered by the WCA to be official.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/kRs3u54kMbI"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="kRs3u54kMbI" />
 
 ## 16.71 (Dan Knights) and 16.53 (Jess Bonde) - World Rubik's Games Championship (2003)
 
@@ -96,37 +91,13 @@ From October 2005 to February 2007, the world record single was reduced to 10.36
 
 ![](img/WRSingles2H/11.75to10.36.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/2BcxVZvIxTI"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="2BcxVZvIxTI" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/uNBFGl7ErJE"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="uNBFGl7ErJE" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/zHTuvB9Vm9s"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="zHTuvB9Vm9s" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/WpqYc_P51N4"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="WpqYc_P51N4" />
 
 ## 9.86 (Thibaut Jacquinot)
 
@@ -149,29 +120,11 @@ On May 5 2007, the first ever sub-10 world record single solve was set by Thibau
 
 The world record was further reduced to 8.87 seconds from October 2007 to May 2008. This started with a 9.77 from Erik Akkersdijk and was followed by a 9.55 by Ron van Bruchem, a 9.18 by Edouard Chambon, and two 8.72 solves by Yu Nakajima at a single competition in the final two rounds.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/JqFFXs0RAnI"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="JqFFXs0RAnI" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/PLOT1Z_c1Dc"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="PLOT1Z_c1Dc" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/J25n7OOdnMI"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="J25n7OOdnMI" />
 
 ## 7.08 (Erik Akkersdijk)
 
@@ -184,13 +137,7 @@ The world record was further reduced to 8.87 seconds from October 2007 to May 20
 
 On July 12, 2008, Erik Akkersdijk set a world record of 7.08 seconds. This is one of the most famous world records due to the large solve time drop compared to the previous world record.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/VzGjbjUPVUo"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="VzGjbjUPVUo" />
 
 ## 7.03 to 5.66 (Feliks Zemdegs)
 
@@ -209,61 +156,19 @@ Interestingly, when the 7.08 world record was set, Zemdegs commented that he did
 
 ![](img/WRSingles2H/Zemdegs.png)
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/TiFwEBUKcsY"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="TiFwEBUKcsY" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/t32VQ2HeELA"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="t32VQ2HeELA" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/Vn_-253xO4s"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="Vn_-253xO4s" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/X6zjv-PP24g"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="X6zjv-PP24g" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/wIvHw17vuGU"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="wIvHw17vuGU" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/uIcbAsoT8y0"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="uIcbAsoT8y0" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/3v_Km6cv6DU"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="3v_Km6cv6DU" />
 
 ## 5.55 (Mats Valk) and 5.25 (Collin Burns)
 
@@ -276,21 +181,9 @@ Interestingly, when the 7.08 world record was set, Zemdegs commented that he did
 
 The 5.66 world record from Zemdegs stood for almost two years before being broken. On March 2, 2013, Mats Valk achieved a new world record time of 5.55 seconds. This was followed by a 5.25 second solve from Collin Burns on April 25, 2015.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/nn7svkdrE7I"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="nn7svkdrE7I" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/i8RBl7NmL8g"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="i8RBl7NmL8g" />
 
 ## 4.90 (Lucas Etter)
 
@@ -303,13 +196,7 @@ The 5.66 world record from Zemdegs stood for almost two years before being broke
 
 On November 21, 2015, the first ever sub-5 second official solve was achieved. This world record was set by Lucas Etter.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/vh0W8E4cNkQ"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="vh0W8E4cNkQ" />
 
 ## 4.73 to 4.22
 
@@ -322,47 +209,17 @@ On November 21, 2015, the first ever sub-5 second official solve was achieved. T
 
 From December 2016 to May 2018, the world record was dropped to 4.22 seconds. Starting it off was Zemdegs with a 4.73 second solve, just .01 seconds faster than the world record at the time. This was the return of Zemdegs to the single solve world records, having not set one in around five and a half years.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/R07JiT0PlcE"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="R07JiT0PlcE" />
 
 Ten months later, on September 2, 2017, Patrick Ponce achieved a world record of 4.69 seconds. This was followed by SeungBeom Cho in October 2017 with a 4.59 second solve. In early 2018, Zemdegs returned yet again to the single solve world records, first matching the 4.59 second record in January then a 4.22 in May.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/np2G0yr5xI0"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="np2G0yr5xI0" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/5x8jgGX3iNM"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="5x8jgGX3iNM" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/Sz67ipXnKNg"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="Sz67ipXnKNg" />
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/NevGDFBfQGw"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="NevGDFBfQGw" />
 
 ## 3.47 (Yusheng Du)
 
@@ -379,13 +236,7 @@ The length that the world record stood can potentially be attributed to the impa
 
 The solve was also the subject of some controversy. Yusheng Du’s averages at the competition over three rounds were: [11.13 (3.47) 8.80 (DNF) 7.07], [(6.95) 7.72 8.20 (10.43) 9.62], and [(8.01) 8.84 8.42 (11.02) 9.44]. The 3.47 solve was viewed as extremely low compared to the remainder of the solves within the averages. The footage of the solve was also of low quality. These aspects led some to doubt the authenticity of the solve [5].
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/SB3ut65SFUU"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="SB3ut65SFUU" />
 
 ## 3.13 (Max Park)
 
@@ -398,13 +249,7 @@ The solve was also the subject of some controversy. Yusheng Du’s averages at t
 
 The world record was finally beaten again on June 11, 2023. After years of attaining world records in the 3x3 2H average category and in other events, Max Park set a world record single solve time of 3.13 seconds.
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe loading="lazy" width="100%" height="100%"
-    src="https://www.youtube.com/embed/gh8HX4itF_w"
-    frameborder="0" allowfullscreen
-    style={{position: 'absolute', top: 0, left: 0}}>
-  </iframe>
-</div>
+<YouTube embedId="gh8HX4itF_w" />
 
 ## Sources
 

--- a/src/components/YouTube/index.js
+++ b/src/components/YouTube/index.js
@@ -1,0 +1,20 @@
+/**
+ * YouTube video embed. Uses youtube-nocookie.com for better privacy
+ * @example
+ * <YouTube embedId="R07JiT0PlcE" />
+ */
+export default function YouTube({ embedId }) {
+  return (
+    <div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
+      <iframe
+        loading="lazy"
+        width="100%"
+        height="100%"
+        src={`https://www.youtube-nocookie.com/embed/${embedId}`}
+        allow="accelerometer; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
+        frameborder="0"
+        style={{position: 'absolute', top: 0, left: 0}}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
I noticed that YouTube video embeds can't open in fullscreen, even though the iframe `allowfullscreen` attribute is used in every embed across the site. Turns out that newer browsers no longer support it, now replaced with `allow="fullscreen"

This PR restores fullscreen functionality, and adds other permissions like picture-in-picture mode, autorotate on mobile screens etc. It also changes the `youtube.com/embed/...` URLs to YouTube's `youtube-nocookie.com/embed/...` for better privacy.

I also extracted the embed code into a React component, making it easy to embed a video in one line. All 78 embeds have been updated via find-and-replace to use it.

Before:
```jsx
<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
  <iframe loading="lazy" width="100%" height="100%"
    src="https://www.youtube.com/embed/ABCD1234"
    frameborder="0" allowfullscreen
    style={{position: 'absolute', top: 0, left: 0}}>
  </iframe>
</div>
```

After:

```jsx
<YouTube embedId="ABCD1234" />
```